### PR TITLE
feat(og): add opengraph image for SSO authorize page

### DIFF
--- a/app/sso-authorize/opengraph-image.tsx
+++ b/app/sso-authorize/opengraph-image.tsx
@@ -1,7 +1,7 @@
 /**
  * @author Claude
- * @version 1.8
- * @date 2026/4/22 15:08:00
+ * @version 2.4
+ * @date 2026/4/23 12:43:04
  *
  * Generates the Open Graph / iMessage link-preview image for the
  * SSO authorize page via Next.js ImageResponse (next/og).
@@ -10,13 +10,20 @@
  * generated at build-prep time from public/icon-1024.png.
  * No filesystem or network access at request time — fully compatible
  * with the Cloudflare Workers Edge runtime (@opennextjs/cloudflare).
+ *
+ * Layout: icon on the left, title + description on the right,
+ * both vertically centred. Text is left-aligned.
  */
 import { ImageResponse } from 'next/og';
 import { ICON_DATA_URL } from './og-icon-b64';
 
+export const dynamic = 'force-static';
 export const alt = 'Authorize Ham';
-export const size = { width: 1200, height: 630 };
+export const size = { width: 1200, height: 680 };
 export const contentType = 'image/png';
+
+const title = 'Authorize Ham';
+const description = 'Sign in to Ham to authorize third-party apps.';
 
 export default async function OgImage() {
 	return new ImageResponse(
@@ -26,48 +33,62 @@ export default async function OgImage() {
 					width: '100%',
 					height: '100%',
 					display: 'flex',
-					flexDirection: 'column',
+					flexDirection: 'row',
 					alignItems: 'center',
 					justifyContent: 'center',
-					background: 'linear-gradient(135deg, #0f0f0f 0%, #1a1a2e 100%)',
+					background: 'linear-gradient(135deg, #f5f5f7 0%, #e8eaf6 100%)',
 					fontFamily:
 						'-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+					padding: '0 80px',
+					gap: 48,
 				}}
 			>
 				{/* App icon */}
 				<img
 					src={ICON_DATA_URL}
-					width={120}
-					height={120}
+					width={180}
+					height={180}
 					style={{
-						borderRadius: 28,
-						marginBottom: 32,
+						borderRadius: 40,
+						flexShrink: 0,
 						boxShadow: '0 20px 60px rgba(99,102,241,0.4)',
 					}}
 				/>
 
-				{/* Title */}
+				{/* Text block */}
 				<div
 					style={{
-						fontSize: 52,
-						fontWeight: 700,
-						color: '#ffffff',
-						letterSpacing: -1,
-						marginBottom: 16,
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'flex-start',
+						justifyContent: 'center',
+						gap: 12,
 					}}
 				>
-					Authorize Ham
-				</div>
+					{/* Title */}
+					<div
+						style={{
+							fontSize: 72,
+							fontWeight: 700,
+							color: '#1a1a2e',
+							letterSpacing: -1,
+							lineHeight: 1.1,
+						}}
+					>
+						{title}
+					</div>
 
-				{/* Subtitle */}
-				<div
-					style={{
-						fontSize: 26,
-						color: 'rgba(255,255,255,0.55)',
-						letterSpacing: 0,
-					}}
-				>
-					Sign in to continue
+					{/* Description */}
+					<div
+						style={{
+							fontSize: 36,
+							color: 'rgba(26,26,46,0.5)',
+							letterSpacing: 0,
+							lineHeight: 1.4,
+						}}
+					>
+						{description}
+					</div>
 				</div>
 			</div>
 		),

--- a/app/sso-authorize/page.tsx
+++ b/app/sso-authorize/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata(): Promise<Metadata> {
 				{
 					url: '/sso-authorize/opengraph-image',
 					width: 1200,
-					height: 630,
+					height: 400,
 					alt: title,
 				},
 			],


### PR DESCRIPTION
## Summary

Adds a static Open Graph / iMessage link-preview image for the SSO authorize page.

### Changes
- `opengraph-image.tsx` — new `ImageResponse` component with left-right layout (icon + text), light gradient background, fully static (`force-static`)
- Icon inlined as base64 data URL (`og-icon-b64.ts`) — no filesystem/network access at request time, compatible with Cloudflare Workers Edge runtime
- Iteratively refined: layout, sizing, colors, description copy, icon & font sizes enlarged

### Layout
- **Left**: app icon (180×180, rounded)
- **Right**: title (72px bold) + description (36px muted)
- Vertically centred, text left-aligned
- Canvas: 1200×680 px