### PR TITLE
fix(og): sync OG image height to 680 in page metadata

### DIFF
--- a/app/sso-authorize/page.tsx
+++ b/app/sso-authorize/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata(): Promise<Metadata> {
 				{
 					url: '/sso-authorize/opengraph-image',
 					width: 1200,
-					height: 400,
+					height: 680,
 					alt: title,
 				},
 			],


### PR DESCRIPTION
## Summary

Fixes the OG image height declared in `page.tsx` metadata to match the actual canvas size in `opengraph-image.tsx`.

### Change
- `page.tsx`: `height: 400` → `height: 680` to match `export const size = { width: 1200, height: 680 }`