### PR TITLE
feat: migrate api routes to EdgeOne edge functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ next-env.d.ts
 
 .open-next
 .wrangler
+
+# Tencent Cloud EdgeOne
+.env
+.edgeone/
+.tef_dist/

--- a/edge-functions/_proxy.ts
+++ b/edge-functions/_proxy.ts
@@ -1,0 +1,45 @@
+/**
+ * @author Claude
+ * @version 1.0
+ * @date 2026/4/23 20:31:47
+ *
+ * Shared BFF proxy helper used by all EdgeOne Edge Function handlers.
+ * Forwards requests to the backend origin (env var HAM_BACKEND_ORIGIN)
+ * and streams the response back to the client, preserving status codes,
+ * headers, and cookies.
+ */
+
+/**
+ * Proxy an incoming Request to the backend and return the backend Response.
+ * @param req     The incoming Request object.
+ * @param path    The backend path to forward to (e.g. "/web/auth/me").
+ * @param env     The EdgeOne environment bindings (must contain HAM_BACKEND_ORIGIN).
+ */
+export async function proxyToBackend(
+	req: Request,
+	path: string,
+	env: Record<string, string>
+): Promise<Response> {
+	const origin = env.HAM_BACKEND_ORIGIN ?? '';
+	const url = `${origin}${path}`;
+
+	// Forward all original headers except Host (set automatically by fetch).
+	const forwardHeaders = new Headers(req.headers);
+	forwardHeaders.delete('host');
+
+	const upstreamRes = await fetch(url, {
+		method: req.method,
+		headers: forwardHeaders,
+		body: req.method !== 'GET' && req.method !== 'HEAD' ? req.body : undefined,
+	});
+
+	// Copy response headers back to the client (including Set-Cookie).
+	const resHeaders = new Headers(upstreamRes.headers);
+	// Remove transfer-encoding — the edge runtime handles chunking itself.
+	resHeaders.delete('transfer-encoding');
+
+	return new Response(upstreamRes.body, {
+		status: upstreamRes.status,
+		headers: resHeaders,
+	});
+}

--- a/edge-functions/api/auth/logout.ts
+++ b/edge-functions/api/auth/logout.ts
@@ -1,0 +1,16 @@
+/**
+ * @author Claude
+ * @version 1.0
+ * @date 2026/4/23 20:31:47
+ *
+ * EdgeOne Edge Function: POST /api/auth/logout
+ * Proxies session logout to the backend.
+ */
+import { proxyToBackend } from '../../_proxy';
+
+export async function onRequestPost(context: {
+	request: Request;
+	env: Record<string, string>;
+}): Promise<Response> {
+	return proxyToBackend(context.request, '/web/auth/logout', context.env);
+}

--- a/edge-functions/api/auth/me.ts
+++ b/edge-functions/api/auth/me.ts
@@ -1,0 +1,16 @@
+/**
+ * @author Claude
+ * @version 1.0
+ * @date 2026/4/23 20:31:47
+ *
+ * EdgeOne Edge Function: GET /api/auth/me
+ * Proxies the current-user session check to the backend.
+ */
+import { proxyToBackend } from '../../_proxy';
+
+export async function onRequestGet(context: {
+	request: Request;
+	env: Record<string, string>;
+}): Promise<Response> {
+	return proxyToBackend(context.request, '/web/auth/me', context.env);
+}

--- a/edge-functions/api/auth/passkey/login.ts
+++ b/edge-functions/api/auth/passkey/login.ts
@@ -1,0 +1,20 @@
+/**
+ * @author Claude
+ * @version 1.0
+ * @date 2026/4/23 20:31:47
+ *
+ * EdgeOne Edge Function: POST /api/auth/passkey/login
+ * Proxies passkey assertion verification to the backend.
+ */
+import { proxyToBackend } from '../../../_proxy';
+
+export async function onRequestPost(context: {
+	request: Request;
+	env: Record<string, string>;
+}): Promise<Response> {
+	return proxyToBackend(
+		context.request,
+		'/web/auth/passkey/login',
+		context.env
+	);
+}

--- a/edge-functions/api/auth/passkey/option.ts
+++ b/edge-functions/api/auth/passkey/option.ts
@@ -1,0 +1,20 @@
+/**
+ * @author Claude
+ * @version 1.0
+ * @date 2026/4/23 20:31:47
+ *
+ * EdgeOne Edge Function: POST /api/auth/passkey/option
+ * Proxies passkey challenge option request to the backend.
+ */
+import { proxyToBackend } from '../../../_proxy';
+
+export async function onRequestPost(context: {
+	request: Request;
+	env: Record<string, string>;
+}): Promise<Response> {
+	return proxyToBackend(
+		context.request,
+		'/web/auth/passkey/option',
+		context.env
+	);
+}

--- a/edge-functions/api/auth/qr/ticket.ts
+++ b/edge-functions/api/auth/qr/ticket.ts
@@ -1,0 +1,16 @@
+/**
+ * @author Claude
+ * @version 1.0
+ * @date 2026/4/23 20:31:47
+ *
+ * EdgeOne Edge Function: POST /api/auth/qr/ticket
+ * Proxies QR ticket creation to the backend.
+ */
+import { proxyToBackend } from '../../../_proxy';
+
+export async function onRequestPost(context: {
+	request: Request;
+	env: Record<string, string>;
+}): Promise<Response> {
+	return proxyToBackend(context.request, '/web/auth/qr/ticket', context.env);
+}

--- a/edge-functions/api/auth/qr/ticket/[ticket].ts
+++ b/edge-functions/api/auth/qr/ticket/[ticket].ts
@@ -1,0 +1,23 @@
+/**
+ * @author Claude
+ * @version 1.0
+ * @date 2026/4/23 20:31:47
+ *
+ * EdgeOne Edge Function: GET /api/auth/qr/ticket/[ticket]
+ * Proxies QR ticket status polling to the backend.
+ * The dynamic segment [ticket] is available via context.params.ticket.
+ */
+import { proxyToBackend } from '../../../../_proxy';
+
+export async function onRequestGet(context: {
+	request: Request;
+	env: Record<string, string>;
+	params: Record<string, string>;
+}): Promise<Response> {
+	const ticket = encodeURIComponent(context.params.ticket ?? '');
+	return proxyToBackend(
+		context.request,
+		`/web/auth/qr/ticket/${ticket}`,
+		context.env
+	);
+}

--- a/edge-functions/api/auth/refresh.ts
+++ b/edge-functions/api/auth/refresh.ts
@@ -1,0 +1,16 @@
+/**
+ * @author Claude
+ * @version 1.0
+ * @date 2026/4/23 20:31:47
+ *
+ * EdgeOne Edge Function: POST /api/auth/refresh
+ * Proxies session token refresh to the backend.
+ */
+import { proxyToBackend } from '../../_proxy';
+
+export async function onRequestPost(context: {
+	request: Request;
+	env: Record<string, string>;
+}): Promise<Response> {
+	return proxyToBackend(context.request, '/web/auth/refresh', context.env);
+}

--- a/edge-functions/api/sso/consent/confirm.ts
+++ b/edge-functions/api/sso/consent/confirm.ts
@@ -1,0 +1,20 @@
+/**
+ * @author Claude
+ * @version 1.0
+ * @date 2026/4/23 20:31:47
+ *
+ * EdgeOne Edge Function: POST /api/sso/consent/confirm
+ * Proxies consent confirmation to the backend.
+ */
+import { proxyToBackend } from '../../../_proxy';
+
+export async function onRequestPost(context: {
+	request: Request;
+	env: Record<string, string>;
+}): Promise<Response> {
+	return proxyToBackend(
+		context.request,
+		'/web/sso/consent/confirm',
+		context.env
+	);
+}

--- a/edge-functions/api/sso/consent/info.ts
+++ b/edge-functions/api/sso/consent/info.ts
@@ -1,0 +1,16 @@
+/**
+ * @author Claude
+ * @version 1.0
+ * @date 2026/4/23 20:31:47
+ *
+ * EdgeOne Edge Function: POST /api/sso/consent/info
+ * Proxies consent info retrieval to the backend.
+ */
+import { proxyToBackend } from '../../../_proxy';
+
+export async function onRequestPost(context: {
+	request: Request;
+	env: Record<string, string>;
+}): Promise<Response> {
+	return proxyToBackend(context.request, '/web/sso/consent/info', context.env);
+}


### PR DESCRIPTION
## Summary

Migrate Next.js API route handlers to EdgeOne Edge Functions as a BFF layer.

## Changes

### New Files
- `edge-functions/_proxy.ts` — shared proxy utility for forwarding requests to the backend
- `edge-functions/api/auth/logout.ts` — logout endpoint
- `edge-functions/api/auth/me.ts` — current user info endpoint
- `edge-functions/api/auth/passkey/login.ts` — passkey login endpoint
- `edge-functions/api/auth/passkey/option.ts` — passkey options endpoint
- `edge-functions/api/auth/qr/ticket.ts` — QR ticket creation endpoint
- `edge-functions/api/auth/qr/ticket/[ticket].ts` — QR ticket polling endpoint
- `edge-functions/api/auth/refresh.ts` — token refresh endpoint
- `edge-functions/api/sso/consent/confirm.ts` — SSO consent confirm endpoint
- `edge-functions/api/sso/consent/info.ts` — SSO consent info endpoint

### Modified
- `.gitignore` — updated ignore rules

## Architecture

```
Client → EdgeOne Edge Function (/api/**)
              ↓ (other page requests)
       Cloudflare Workers (Next.js)
```

All `/api/**` requests are now intercepted and handled at the EdgeOne edge layer, reducing latency and offloading BFF logic from the Next.js origin.