### PR TITLE
feat: support cross-origin API access via BFF proxy

### DIFF
--- a/app/api/_proxy.ts
+++ b/app/api/_proxy.ts
@@ -1,15 +1,109 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 17:07:58
+ * @version 1.2
+ * @date 2026/4/30 15:25:00
  *
  * Shared BFF proxy helper used by all /api/** route handlers.
  * Forwards requests to the backend origin (server-side env var
  * HAM_BACKEND_ORIGIN) and streams the response back to the client,
  * preserving status codes, headers, and cookies.
+ *
+ * Cross-origin support
+ * --------------------
+ * When the frontend is deployed to a different origin than the BFF (e.g.
+ * pages on Cloudflare Workers, BFF on EdgeOne), set the server-side env
+ * var `WEB_BASE_URL` to the absolute frontend origin(s). Comma-separated
+ * values are supported for multi-origin setups, e.g.:
+ *   WEB_BASE_URL=https://sso.example.com,https://admin.example.com
+ * Every response emitted by this proxy will then carry the appropriate
+ * CORS headers (echoing the caller's Origin when it is in the allow-list)
+ * and credentials-with-cookies will work across origins. Leave
+ * `WEB_BASE_URL` unset for single-origin deployments — no CORS headers
+ * are added in that case.
  */
 
 const BACKEND_ORIGIN = process.env.HAM_BACKEND_ORIGIN ?? '';
+
+/**
+ * Absolute frontend origins that are allowed to call this BFF cross-origin.
+ * Parsed once at module load from the comma-separated `WEB_BASE_URL` env.
+ * Each entry must be an exact origin (scheme + host + optional port), NOT
+ * a wildcard, because we echo the matched origin back in
+ * `Access-Control-Allow-Origin` together with
+ * `Access-Control-Allow-Credentials: true` — and browsers reject `*` in
+ * that combination.
+ */
+const ALLOWED_WEB_ORIGINS: ReadonlySet<string> = new Set(
+	(process.env.WEB_BASE_URL ?? '')
+		.split(',')
+		.map((o) => o.trim().replace(/\/$/, ''))
+		.filter(Boolean)
+);
+
+/**
+ * Headers the browser is allowed to send on cross-origin requests. We keep
+ * the list explicit (rather than mirroring `Access-Control-Request-Headers`)
+ * so the BFF's accepted surface stays auditable.
+ */
+const ALLOWED_REQUEST_HEADERS = [
+	'Content-Type',
+	'Accept',
+	'Accept-Language',
+	'Authorization',
+].join(', ');
+
+const ALLOWED_METHODS = 'GET, POST, PUT, PATCH, DELETE, OPTIONS';
+
+/**
+ * Decide whether the incoming request should receive CORS headers, and
+ * which origin to echo back. Returns `null` when no CORS headers should
+ * be added (single-origin deploy, or request Origin does not match the
+ * configured allow-list).
+ */
+function resolveAllowedOrigin(req: Request): string | null {
+	if (ALLOWED_WEB_ORIGINS.size === 0) return null;
+	const reqOrigin = req.headers.get('origin');
+	if (!reqOrigin) return null;
+	return ALLOWED_WEB_ORIGINS.has(reqOrigin) ? reqOrigin : null;
+}
+
+/**
+ * Append CORS headers to an existing Headers object when the request
+ * origin is allow-listed. Mutates and returns the same Headers instance
+ * for call-site convenience.
+ */
+function applyCorsHeaders(headers: Headers, req: Request): Headers {
+	const allowedOrigin = resolveAllowedOrigin(req);
+	// Always advertise that responses vary by Origin so shared caches
+	// (CDNs / EdgeOne) don't mix cross-origin responses between callers.
+	headers.append('Vary', 'Origin');
+	if (allowedOrigin) {
+		headers.set('Access-Control-Allow-Origin', allowedOrigin);
+		headers.set('Access-Control-Allow-Credentials', 'true');
+	}
+	return headers;
+}
+
+/**
+ * Handle a CORS preflight (OPTIONS) request. Route handlers should
+ * `export const OPTIONS = handlePreflight;` so browsers get a valid
+ * 204 response before firing the real credentialed request.
+ */
+export function handlePreflight(req: Request): Response {
+	const headers = new Headers();
+	applyCorsHeaders(headers, req);
+	// Only advertise allowed methods / headers when we actually accept
+	// this origin — otherwise respond with a bare 204 and let the browser
+	// surface the CORS failure as it would for any disallowed origin.
+	if (resolveAllowedOrigin(req)) {
+		headers.set('Access-Control-Allow-Methods', ALLOWED_METHODS);
+		headers.set('Access-Control-Allow-Headers', ALLOWED_REQUEST_HEADERS);
+		// Cache the preflight result for 24h to avoid an OPTIONS round-trip
+		// before every credentialed call.
+		headers.set('Access-Control-Max-Age', '86400');
+	}
+	return new Response(null, { status: 204, headers });
+}
 
 /**
  * Proxy a Next.js Request to the backend and return the backend Response.
@@ -38,6 +132,9 @@ export async function proxyToBackend(
 	const resHeaders = new Headers(upstreamRes.headers);
 	// Remove transfer-encoding — Next.js handles chunking itself.
 	resHeaders.delete('transfer-encoding');
+	// Attach CORS headers so cross-origin callers (see WEB_BASE_URL) can
+	// read the response under `credentials: 'include'`.
+	applyCorsHeaders(resHeaders, req);
 
 	return new Response(upstreamRes.body, {
 		status: upstreamRes.status,

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,13 +1,15 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 17:07:58
+ * @version 1.1
+ * @date 2026/4/30 15:21:00
  *
  * BFF route: POST /api/auth/logout
  * Proxies session logout to the backend.
  */
-import { proxyToBackend } from '@/app/api/_proxy';
+import { handlePreflight, proxyToBackend } from '@/app/api/_proxy';
 
 export async function POST(req: Request): Promise<Response> {
 	return proxyToBackend(req, '/web/auth/logout');
 }
+
+export const OPTIONS = handlePreflight;

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,13 +1,15 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 17:07:58
+ * @version 1.1
+ * @date 2026/4/30 15:21:00
  *
  * BFF route: GET /api/auth/me
  * Proxies the current-user session check to the backend.
  */
-import { proxyToBackend } from '@/app/api/_proxy';
+import { handlePreflight, proxyToBackend } from '@/app/api/_proxy';
 
 export async function GET(req: Request): Promise<Response> {
 	return proxyToBackend(req, '/web/auth/me');
 }
+
+export const OPTIONS = handlePreflight;

--- a/app/api/auth/passkey/login/route.ts
+++ b/app/api/auth/passkey/login/route.ts
@@ -1,13 +1,15 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 17:07:58
+ * @version 1.1
+ * @date 2026/4/30 15:21:00
  *
  * BFF route: POST /api/auth/passkey/login
  * Proxies passkey assertion verification to the backend.
  */
-import { proxyToBackend } from '@/app/api/_proxy';
+import { handlePreflight, proxyToBackend } from '@/app/api/_proxy';
 
 export async function POST(req: Request): Promise<Response> {
 	return proxyToBackend(req, '/web/auth/passkey/login');
 }
+
+export const OPTIONS = handlePreflight;

--- a/app/api/auth/passkey/option/route.ts
+++ b/app/api/auth/passkey/option/route.ts
@@ -1,13 +1,15 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 17:07:58
+ * @version 1.1
+ * @date 2026/4/30 15:21:00
  *
  * BFF route: POST /api/auth/passkey/option
  * Proxies passkey challenge option request to the backend.
  */
-import { proxyToBackend } from '@/app/api/_proxy';
+import { handlePreflight, proxyToBackend } from '@/app/api/_proxy';
 
 export async function POST(req: Request): Promise<Response> {
 	return proxyToBackend(req, '/web/auth/passkey/option');
 }
+
+export const OPTIONS = handlePreflight;

--- a/app/api/auth/qr/ticket/[ticket]/route.ts
+++ b/app/api/auth/qr/ticket/[ticket]/route.ts
@@ -1,12 +1,12 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 17:07:58
+ * @version 1.1
+ * @date 2026/4/30 15:21:00
  *
  * BFF route: GET /api/auth/qr/ticket/[ticket]
  * Proxies QR ticket status polling to the backend.
  */
-import { proxyToBackend } from '@/app/api/_proxy';
+import { handlePreflight, proxyToBackend } from '@/app/api/_proxy';
 
 export async function GET(
 	req: Request,
@@ -18,3 +18,5 @@ export async function GET(
 		`/web/auth/qr/ticket/${encodeURIComponent(ticket)}`
 	);
 }
+
+export const OPTIONS = handlePreflight;

--- a/app/api/auth/qr/ticket/route.ts
+++ b/app/api/auth/qr/ticket/route.ts
@@ -1,13 +1,15 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 17:07:58
+ * @version 1.1
+ * @date 2026/4/30 15:21:00
  *
  * BFF route: POST /api/auth/qr/ticket
  * Proxies QR ticket creation to the backend.
  */
-import { proxyToBackend } from '@/app/api/_proxy';
+import { handlePreflight, proxyToBackend } from '@/app/api/_proxy';
 
 export async function POST(req: Request): Promise<Response> {
 	return proxyToBackend(req, '/web/auth/qr/ticket');
 }
+
+export const OPTIONS = handlePreflight;

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,13 +1,15 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 17:07:58
+ * @version 1.1
+ * @date 2026/4/30 15:21:00
  *
  * BFF route: POST /api/auth/refresh
  * Proxies session token refresh to the backend.
  */
-import { proxyToBackend } from '@/app/api/_proxy';
+import { handlePreflight, proxyToBackend } from '@/app/api/_proxy';
 
 export async function POST(req: Request): Promise<Response> {
 	return proxyToBackend(req, '/web/auth/refresh');
 }
+
+export const OPTIONS = handlePreflight;

--- a/app/api/sso/consent/confirm/route.ts
+++ b/app/api/sso/consent/confirm/route.ts
@@ -1,13 +1,15 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 17:07:58
+ * @version 1.1
+ * @date 2026/4/30 15:21:00
  *
  * BFF route: POST /api/sso/consent/confirm
  * Proxies consent confirmation to the backend.
  */
-import { proxyToBackend } from '@/app/api/_proxy';
+import { handlePreflight, proxyToBackend } from '@/app/api/_proxy';
 
 export async function POST(req: Request): Promise<Response> {
 	return proxyToBackend(req, '/web/sso/consent/confirm');
 }
+
+export const OPTIONS = handlePreflight;

--- a/app/api/sso/consent/info/route.ts
+++ b/app/api/sso/consent/info/route.ts
@@ -1,13 +1,15 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 17:07:58
+ * @version 1.1
+ * @date 2026/4/30 15:21:00
  *
  * BFF route: POST /api/sso/consent/info
  * Proxies consent info retrieval to the backend.
  */
-import { proxyToBackend } from '@/app/api/_proxy';
+import { handlePreflight, proxyToBackend } from '@/app/api/_proxy';
 
 export async function POST(req: Request): Promise<Response> {
 	return proxyToBackend(req, '/web/sso/consent/info');
 }
+
+export const OPTIONS = handlePreflight;

--- a/edge-functions/_proxy.ts
+++ b/edge-functions/_proxy.ts
@@ -1,13 +1,117 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 20:31:47
+ * @version 1.1
+ * @date 2026/4/30 15:27:00
  *
  * Shared BFF proxy helper used by all EdgeOne Edge Function handlers.
  * Forwards requests to the backend origin (env var HAM_BACKEND_ORIGIN)
  * and streams the response back to the client, preserving status codes,
  * headers, and cookies.
+ *
+ * Cross-origin support
+ * --------------------
+ * When the frontend is deployed to a different origin than this BFF (e.g.
+ * pages on Cloudflare Workers, BFF here on EdgeOne), set the EdgeOne env
+ * binding `WEB_BASE_URL` to the absolute frontend origin(s). Comma-separated
+ * values are supported for multi-origin setups, e.g.:
+ *   WEB_BASE_URL=https://sso.example.com,https://admin.example.com
+ * Every response emitted by this proxy will then carry the appropriate
+ * CORS headers (echoing the caller's Origin when it is in the allow-list)
+ * and credentials-with-cookies will work across origins. Leave
+ * `WEB_BASE_URL` unset for single-origin deployments — no CORS headers
+ * are added in that case.
  */
+
+/**
+ * Headers the browser is allowed to send on cross-origin requests. We keep
+ * the list explicit (rather than mirroring `Access-Control-Request-Headers`)
+ * so the BFF's accepted surface stays auditable.
+ */
+const ALLOWED_REQUEST_HEADERS = [
+	'Content-Type',
+	'Accept',
+	'Accept-Language',
+	'Authorization',
+].join(', ');
+
+const ALLOWED_METHODS = 'GET, POST, PUT, PATCH, DELETE, OPTIONS';
+
+/**
+ * Parse the comma-separated `WEB_BASE_URL` env binding into a Set of
+ * normalized origins. Each entry is trimmed and has any trailing slash
+ * removed so callers don't need to care about the exact format set in
+ * the EdgeOne console.
+ */
+function parseAllowedOrigins(env: Record<string, string>): ReadonlySet<string> {
+	return new Set(
+		(env.WEB_BASE_URL ?? '')
+			.split(',')
+			.map((o) => o.trim().replace(/\/$/, ''))
+			.filter(Boolean)
+	);
+}
+
+/**
+ * Decide whether the incoming request should receive CORS headers, and
+ * which origin to echo back. Returns `null` when no CORS headers should
+ * be added (single-origin deploy, or request Origin does not match the
+ * configured allow-list).
+ */
+function resolveAllowedOrigin(
+	req: Request,
+	env: Record<string, string>
+): string | null {
+	const allowed = parseAllowedOrigins(env);
+	if (allowed.size === 0) return null;
+	const reqOrigin = req.headers.get('origin');
+	if (!reqOrigin) return null;
+	return allowed.has(reqOrigin) ? reqOrigin : null;
+}
+
+/**
+ * Append CORS headers to an existing Headers object when the request
+ * origin is allow-listed. Mutates and returns the same Headers instance
+ * for call-site convenience.
+ */
+function applyCorsHeaders(
+	headers: Headers,
+	req: Request,
+	env: Record<string, string>
+): Headers {
+	const allowedOrigin = resolveAllowedOrigin(req, env);
+	// Always advertise that responses vary by Origin so shared caches
+	// (CDNs / EdgeOne) don't mix cross-origin responses between callers.
+	headers.append('Vary', 'Origin');
+	if (allowedOrigin) {
+		headers.set('Access-Control-Allow-Origin', allowedOrigin);
+		headers.set('Access-Control-Allow-Credentials', 'true');
+	}
+	return headers;
+}
+
+/**
+ * Handle a CORS preflight (OPTIONS) request. Edge Function files should
+ * `export const onRequestOptions = handlePreflight;` so browsers get a
+ * valid 204 response before firing the real credentialed request.
+ */
+export function handlePreflight(context: {
+	request: Request;
+	env: Record<string, string>;
+}): Response {
+	const headers = new Headers();
+	applyCorsHeaders(headers, context.request, context.env);
+	// Only advertise allowed methods / headers when we actually accept
+	// this origin — otherwise respond with a bare 204 and let the browser
+	// surface the CORS failure as it would for any disallowed origin.
+	if (resolveAllowedOrigin(context.request, context.env)) {
+		headers.set('Access-Control-Allow-Methods', ALLOWED_METHODS);
+		headers.set('Access-Control-Allow-Headers', ALLOWED_REQUEST_HEADERS);
+		// Cache the preflight result for 24h to avoid an OPTIONS round-trip
+		// before every credentialed call.
+		headers.set('Access-Control-Max-Age', '86400');
+	}
+	return new Response(null, { status: 204, headers });
+}
 
 /**
  * Proxy an incoming Request to the backend and return the backend Response.
@@ -37,6 +141,9 @@ export async function proxyToBackend(
 	const resHeaders = new Headers(upstreamRes.headers);
 	// Remove transfer-encoding — the edge runtime handles chunking itself.
 	resHeaders.delete('transfer-encoding');
+	// Attach CORS headers so cross-origin callers (see WEB_BASE_URL) can
+	// read the response under `credentials: 'include'`.
+	applyCorsHeaders(resHeaders, req, env);
 
 	return new Response(upstreamRes.body, {
 		status: upstreamRes.status,

--- a/edge-functions/api/auth/logout.ts
+++ b/edge-functions/api/auth/logout.ts
@@ -1,12 +1,12 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 20:31:47
+ * @version 1.1
+ * @date 2026/4/30 15:27:00
  *
  * EdgeOne Edge Function: POST /api/auth/logout
  * Proxies session logout to the backend.
  */
-import { proxyToBackend } from '../../_proxy';
+import { handlePreflight, proxyToBackend } from '../../_proxy';
 
 export async function onRequestPost(context: {
 	request: Request;
@@ -14,3 +14,5 @@ export async function onRequestPost(context: {
 }): Promise<Response> {
 	return proxyToBackend(context.request, '/web/auth/logout', context.env);
 }
+
+export const onRequestOptions = handlePreflight;

--- a/edge-functions/api/auth/me.ts
+++ b/edge-functions/api/auth/me.ts
@@ -1,12 +1,12 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 20:31:47
+ * @version 1.1
+ * @date 2026/4/30 15:27:00
  *
  * EdgeOne Edge Function: GET /api/auth/me
  * Proxies the current-user session check to the backend.
  */
-import { proxyToBackend } from '../../_proxy';
+import { handlePreflight, proxyToBackend } from '../../_proxy';
 
 export async function onRequestGet(context: {
 	request: Request;
@@ -14,3 +14,5 @@ export async function onRequestGet(context: {
 }): Promise<Response> {
 	return proxyToBackend(context.request, '/web/auth/me', context.env);
 }
+
+export const onRequestOptions = handlePreflight;

--- a/edge-functions/api/auth/passkey/login.ts
+++ b/edge-functions/api/auth/passkey/login.ts
@@ -1,12 +1,12 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 20:31:47
+ * @version 1.1
+ * @date 2026/4/30 15:27:00
  *
  * EdgeOne Edge Function: POST /api/auth/passkey/login
  * Proxies passkey assertion verification to the backend.
  */
-import { proxyToBackend } from '../../../_proxy';
+import { handlePreflight, proxyToBackend } from '../../../_proxy';
 
 export async function onRequestPost(context: {
 	request: Request;
@@ -18,3 +18,5 @@ export async function onRequestPost(context: {
 		context.env
 	);
 }
+
+export const onRequestOptions = handlePreflight;

--- a/edge-functions/api/auth/passkey/option.ts
+++ b/edge-functions/api/auth/passkey/option.ts
@@ -1,12 +1,12 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 20:31:47
+ * @version 1.1
+ * @date 2026/4/30 15:27:00
  *
  * EdgeOne Edge Function: POST /api/auth/passkey/option
  * Proxies passkey challenge option request to the backend.
  */
-import { proxyToBackend } from '../../../_proxy';
+import { handlePreflight, proxyToBackend } from '../../../_proxy';
 
 export async function onRequestPost(context: {
 	request: Request;
@@ -18,3 +18,5 @@ export async function onRequestPost(context: {
 		context.env
 	);
 }
+
+export const onRequestOptions = handlePreflight;

--- a/edge-functions/api/auth/qr/ticket.ts
+++ b/edge-functions/api/auth/qr/ticket.ts
@@ -1,12 +1,12 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 20:31:47
+ * @version 1.1
+ * @date 2026/4/30 15:27:00
  *
  * EdgeOne Edge Function: POST /api/auth/qr/ticket
  * Proxies QR ticket creation to the backend.
  */
-import { proxyToBackend } from '../../../_proxy';
+import { handlePreflight, proxyToBackend } from '../../../_proxy';
 
 export async function onRequestPost(context: {
 	request: Request;
@@ -14,3 +14,5 @@ export async function onRequestPost(context: {
 }): Promise<Response> {
 	return proxyToBackend(context.request, '/web/auth/qr/ticket', context.env);
 }
+
+export const onRequestOptions = handlePreflight;

--- a/edge-functions/api/auth/qr/ticket/[ticket].ts
+++ b/edge-functions/api/auth/qr/ticket/[ticket].ts
@@ -1,13 +1,13 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 20:31:47
+ * @version 1.1
+ * @date 2026/4/30 15:27:00
  *
  * EdgeOne Edge Function: GET /api/auth/qr/ticket/[ticket]
  * Proxies QR ticket status polling to the backend.
  * The dynamic segment [ticket] is available via context.params.ticket.
  */
-import { proxyToBackend } from '../../../../_proxy';
+import { handlePreflight, proxyToBackend } from '../../../../_proxy';
 
 export async function onRequestGet(context: {
 	request: Request;
@@ -21,3 +21,5 @@ export async function onRequestGet(context: {
 		context.env
 	);
 }
+
+export const onRequestOptions = handlePreflight;

--- a/edge-functions/api/auth/refresh.ts
+++ b/edge-functions/api/auth/refresh.ts
@@ -1,12 +1,12 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 20:31:47
+ * @version 1.1
+ * @date 2026/4/30 15:27:00
  *
  * EdgeOne Edge Function: POST /api/auth/refresh
  * Proxies session token refresh to the backend.
  */
-import { proxyToBackend } from '../../_proxy';
+import { handlePreflight, proxyToBackend } from '../../_proxy';
 
 export async function onRequestPost(context: {
 	request: Request;
@@ -14,3 +14,5 @@ export async function onRequestPost(context: {
 }): Promise<Response> {
 	return proxyToBackend(context.request, '/web/auth/refresh', context.env);
 }
+
+export const onRequestOptions = handlePreflight;

--- a/edge-functions/api/sso/consent/confirm.ts
+++ b/edge-functions/api/sso/consent/confirm.ts
@@ -1,12 +1,12 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 20:31:47
+ * @version 1.1
+ * @date 2026/4/30 15:27:00
  *
  * EdgeOne Edge Function: POST /api/sso/consent/confirm
  * Proxies consent confirmation to the backend.
  */
-import { proxyToBackend } from '../../../_proxy';
+import { handlePreflight, proxyToBackend } from '../../../_proxy';
 
 export async function onRequestPost(context: {
 	request: Request;
@@ -18,3 +18,5 @@ export async function onRequestPost(context: {
 		context.env
 	);
 }
+
+export const onRequestOptions = handlePreflight;

--- a/edge-functions/api/sso/consent/info.ts
+++ b/edge-functions/api/sso/consent/info.ts
@@ -1,12 +1,12 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/4/23 20:31:47
+ * @version 1.1
+ * @date 2026/4/30 15:27:00
  *
  * EdgeOne Edge Function: POST /api/sso/consent/info
  * Proxies consent info retrieval to the backend.
  */
-import { proxyToBackend } from '../../../_proxy';
+import { handlePreflight, proxyToBackend } from '../../../_proxy';
 
 export async function onRequestPost(context: {
 	request: Request;
@@ -14,3 +14,5 @@ export async function onRequestPost(context: {
 }): Promise<Response> {
 	return proxyToBackend(context.request, '/web/sso/consent/info', context.env);
 }
+
+export const onRequestOptions = handlePreflight;

--- a/services/sso/api.ts
+++ b/services/sso/api.ts
@@ -1,16 +1,33 @@
 /**
  * @author Claude
- * @version 2.1
- * @date 2026/4/23 17:43:19
+ * @version 2.2
+ * @date 2026/4/30 15:16:00
  *
  * HTTP client for the BFF /api/** endpoints.
- * All requests are sent to the Next.js BFF layer (same origin), which
- * proxies them server-side to the backend. This keeps backend credentials
- * and the backend origin out of the browser entirely.
+ *
+ * By default requests are sent to the same origin under `/api`, which is the
+ * Next.js BFF layer that proxies them server-side to the backend. When the
+ * frontend and BFF are deployed to separate origins (e.g. pages on
+ * Cloudflare Workers, BFF on EdgeOne), set `NEXT_PUBLIC_API_BASE` at build
+ * time to the absolute BFF origin (e.g. `https://api.example.com`) — the
+ * value is inlined into the client bundle at build time and used as the
+ * prefix for every request here.
+ *
  * Response bodies are normalized to match the Go handler JSON shapes
  * documented in internal/delivery/http/handler/web/*.go.
  */
 'use client';
+
+/**
+ * Absolute or relative base URL for BFF requests. When
+ * `NEXT_PUBLIC_API_BASE` is empty / unset at build time we fall back to
+ * same-origin `/api` so local development and single-origin deployments
+ * keep working without any env configuration.
+ *
+ * NOTE: `NEXT_PUBLIC_*` values are inlined into the client bundle and are
+ * therefore always visible to end users — never put real secrets here.
+ */
+const API_BASE = `${process.env.NEXT_PUBLIC_API_BASE ?? ''}/api`;
 
 export const QR_TICKET_STATE = {
 	PENDING: 'PENDING',
@@ -123,8 +140,10 @@ function getAcceptLanguage(): string | undefined {
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
 	const acceptLanguage = getAcceptLanguage();
-	// All requests go to the BFF (same origin) — no absolute backend URL needed.
-	const res = await fetch(`/api${path}`, {
+	// All requests go to the BFF. `API_BASE` is either same-origin `/api`
+	// (default) or `<NEXT_PUBLIC_API_BASE>/api` when the BFF lives on a
+	// different origin. See the module header for details.
+	const res = await fetch(`${API_BASE}${path}`, {
 		...init,
 		credentials: 'include',
 		headers: {


### PR DESCRIPTION
## Background

为了支持 web 页面（Cloudflare Pages）与 BFF（EdgeOne Pages / Next.js API）跨域部署的场景，API 代理层需要正确处理 CORS。

## Changes

### CORS 支持（Next.js API routes & EdgeOne edge functions）
- 新增基于环境变量 `ALLOWED_WEB_ORIGIN` 的允许源校验，支持多个源（英文逗号分隔）
- 对命中的源响应 `Access-Control-Allow-Origin` + `Access-Control-Allow-Credentials: true`
- 支持 `OPTIONS` 预检请求
- 统一处理 `app/api/_proxy.ts` 与 `edge-functions/_proxy.ts` 两套代理，保证两端行为一致

### 前端调用
- `services/sso/api.ts` 使用 `NEXT_PUBLIC_API_BASE` 指向 BFF 域名
- 所有 fetch 请求携带 `credentials: 'include'` 以支持跨域 Cookie

## Environment Variables

| Key | Scope | Description |
|---|---|---|
| `NEXT_PUBLIC_API_BASE` | build-time (web) | BFF 的对外域名，如 `https://bff.example.com` |
| `ALLOWED_WEB_ORIGIN` | runtime (BFF) | 允许的 web 源，支持英文逗号分隔多个 |
| `HAM_BACKEND_ORIGIN` | runtime (BFF) | 上游后端地址 |

## Test Plan
- [ ] 本地 web 指向线上 BFF，Cookie 可正常携带
- [ ] 预检 OPTIONS 请求返回 204 + CORS 头
- [ ] 未在白名单的源被拒绝