### PR TITLE
feat: show toast on login page when OAuth callback fails

### DIFF
--- a/app/api/auth/app-callback/route.ts
+++ b/app/api/auth/app-callback/route.ts
@@ -1,7 +1,7 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/5/21
+ * @version 1.1
+ * @date 2026/5/25 10:40:45
  *
  * BFF route: POST /api/auth/app-callback
  * Proxies app login callback to the backend.
@@ -9,7 +9,7 @@
 import { handlePreflight, proxyToBackend } from '@/app/api/_proxy';
 
 export const POST = async (req: Request): Promise<Response> => {
-	return proxyToBackend(req, '/api/auth/app-callback');
+	return proxyToBackend(req, '/web/auth/app-callback');
 };
 
 export const OPTIONS = handlePreflight;

--- a/app/login/page.client.tsx
+++ b/app/login/page.client.tsx
@@ -1,7 +1,7 @@
 /**
  * @author Claude
- * @version 1.1
- * @date 2026/5/25 10:46:43
+ * @version 1.2
+ * @date 2026/5/25 10:51:37
  *
  * Client-side login page. Handles QR, passkey, and mobile app login.
  * After successful login, redirects to the URL specified in the
@@ -39,7 +39,7 @@ const LoginPage = ({ from, error }: LoginPageProps) => {
 	// Show toast when redirected back with an error from OAuth callback
 	useEffect(() => {
 		if (error) {
-			toast.error(decodeURIComponent(error));
+			toast.error(error);
 		}
 	}, [error]);
 

--- a/app/login/page.client.tsx
+++ b/app/login/page.client.tsx
@@ -1,4 +1,8 @@
 /**
+ * @author Claude
+ * @version 1.1
+ * @date 2026/5/25 10:46:43
+ *
  * Client-side login page. Handles QR, passkey, and mobile app login.
  * After successful login, redirects to the URL specified in the
  * `from` prop (set by SSR page.tsx).
@@ -11,6 +15,7 @@
 
 import { useSetAtom, useAtomValue } from 'jotai';
 import { useEffect } from 'react';
+import toast from 'react-hot-toast';
 
 import LoginView from '@/app/login/LoginView';
 import { loginSucceededAtom, mobileAtom } from '@/app/login/store';
@@ -19,9 +24,10 @@ import { isMobile } from '@/services/sso/ua';
 
 interface LoginPageProps {
 	from: string;
+	error?: string;
 }
 
-const LoginPage = ({ from }: LoginPageProps) => {
+const LoginPage = ({ from, error }: LoginPageProps) => {
 	const setMobile = useSetAtom(mobileAtom);
 	const setLoginSucceeded = useSetAtom(loginSucceededAtom);
 	const loginSucceeded = useAtomValue(loginSucceededAtom);
@@ -29,6 +35,13 @@ const LoginPage = ({ from }: LoginPageProps) => {
 	useEffect(() => {
 		setMobile(isMobile(navigator.userAgent));
 	}, [setMobile]);
+
+	// Show toast when redirected back with an error from OAuth callback
+	useEffect(() => {
+		if (error) {
+			toast.error(decodeURIComponent(error));
+		}
+	}, [error]);
 
 	// Redirect when login succeeds — session cookie is already set by backend
 	useEffect(() => {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -23,12 +23,12 @@ export const generateMetadata = async (): Promise<Metadata> => {
 };
 
 interface PageProps {
-	searchParams: Promise<{ from?: string }>;
+	searchParams: Promise<{ from?: string; error?: string }>;
 }
 
 const Page = async ({ searchParams }: PageProps) => {
 	const me = await fetchMe();
-	const { from } = await searchParams;
+	const { from, error } = await searchParams;
 
 	if (me) {
 		const headersList = await headers();
@@ -45,7 +45,7 @@ const Page = async ({ searchParams }: PageProps) => {
 
 	return (
 		<Suspense>
-			<LoginPage from={safeFrom} />
+			<LoginPage from={safeFrom} error={error} />
 		</Suspense>
 	);
 };

--- a/edge-functions/api/auth/app-callback.ts
+++ b/edge-functions/api/auth/app-callback.ts
@@ -1,7 +1,7 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/5/21
+ * @version 1.1
+ * @date 2026/5/25 10:42:55
  *
  * EdgeOne Edge Function: POST /api/auth/app-callback
  * Proxies app login callback to the backend.
@@ -12,7 +12,7 @@ export const onRequestPost = async (context: {
 	request: Request;
 	env: Record<string, string>;
 }): Promise<Response> => {
-	return proxyToBackend(context.request, '/api/auth/app-callback', context.env);
+	return proxyToBackend(context.request, '/web/auth/app-callback', context.env);
 };
 
 export const onRequestOptions = handlePreflight;


### PR DESCRIPTION
## Summary

When the OAuth app-callback fails (invalid state, network error, backend error), the user is redirected back to `/login` with an `error` query parameter. Previously this error was silently ignored.

This PR adds a toast notification on the login page to inform the user of the failure reason.

## Changes

- **`app/login/page.tsx`** — Read `error` from `searchParams` and pass it to the client component.
- **`app/login/page.client.tsx`** — Accept `error` prop and show a `toast.error()` via `react-hot-toast` when present.
- **`app/api/auth/app-callback/route.ts`** — Route path updated from `/api/auth/app-callback` to `/web/auth/app-callback`.
- **`edge-functions/api/auth/app-callback.ts`** — Proxy path updated accordingly.