### PR TITLE
feat(sso): support PKCE params in /consent/info

### DIFF
--- a/app/sso-authorize/store.ts
+++ b/app/sso-authorize/store.ts
@@ -1,7 +1,7 @@
 /**
  * @author Claude
- * @version 1.1
- * @date 2026/4/21 14:51:13
+ * @version 1.2
+ * @date 2026/5/26 10:42:28
  *
  * Jotai atoms for the /sso-authorize page.
  *
@@ -27,6 +27,9 @@ export interface SsoAuthorizeParams {
 	scope: string[];
 	state: string;
 	redirectUri: string;
+	codeChallenge?: string;
+	codeChallengeMethod?: string;
+	nonce?: string;
 }
 
 export type Stage =

--- a/app/sso-authorize/useConsent.ts
+++ b/app/sso-authorize/useConsent.ts
@@ -1,7 +1,7 @@
 /**
  * @author Claude
- * @version 1.0
- * @date 2026/5/22
+ * @version 1.1
+ * @date 2026/5/26 10:42:28
  *
  * Custom hook for SSO consent view logic.
  * Handles consent info fetching, scope selection, confirm/reject/switch account.
@@ -117,6 +117,11 @@ export const useConsent = (): UseConsentReturn => {
 			scope: params.scope,
 			redirect_uri: params.redirectUri,
 			state: params.state,
+			...(params.codeChallenge && { code_challenge: params.codeChallenge }),
+			...(params.codeChallengeMethod && {
+				code_challenge_method: params.codeChallengeMethod,
+			}),
+			...(params.nonce && { nonce: params.nonce }),
 		})
 			.then((resp) => {
 				if (cancelled) return;
@@ -133,7 +138,16 @@ export const useConsent = (): UseConsentReturn => {
 		return () => {
 			cancelled = true;
 		};
-	}, [params.appId, params.redirectUri, params.scope, params.state, t]);
+	}, [
+		params.appId,
+		params.codeChallenge,
+		params.codeChallengeMethod,
+		params.nonce,
+		params.redirectUri,
+		params.scope,
+		params.state,
+		t,
+	]);
 
 	return {
 		me,

--- a/app/sso-authorize/useSsoAuthorize.ts
+++ b/app/sso-authorize/useSsoAuthorize.ts
@@ -1,7 +1,7 @@
 /**
  * @author Claude
- * @version 2.2
- * @date 2026/5/22
+ * @version 2.3
+ * @date 2026/5/26 10:42:28
  *
  * Custom hook for /sso-authorize page orchestration.
  *
@@ -49,7 +49,19 @@ const parseParams = (): SsoAuthorizeParams | null => {
 		.map((s) => s.trim())
 		.filter(Boolean);
 	const state = usp.get('state') ?? '';
-	return { appId, scope, state, redirectUri };
+	const codeChallenge = usp.get('code_challenge')?.trim() || undefined;
+	const codeChallengeMethod =
+		usp.get('code_challenge_method')?.trim() || undefined;
+	const nonce = usp.get('nonce')?.trim() || undefined;
+	return {
+		appId,
+		scope,
+		state,
+		redirectUri,
+		codeChallenge,
+		codeChallengeMethod,
+		nonce,
+	};
 };
 
 export const useSsoAuthorize = (me: MeResponse | null) => {

--- a/services/sso/api.ts
+++ b/services/sso/api.ts
@@ -1,7 +1,7 @@
 /**
  * @author Claude
- * @version 2.3
- * @date 2026/5/21
+ * @version 2.4
+ * @date 2026/5/26 10:42:28
  *
  * HTTP client for the BFF /api/auth/** endpoints (SSO & session).
  *
@@ -118,6 +118,9 @@ export const WebAuthApi = {
 		scope: string[];
 		redirect_uri: string;
 		state: string;
+		code_challenge?: string;
+		code_challenge_method?: string;
+		nonce?: string;
 	}) =>
 		request<ConsentInfoResponse>('/sso/consent/info', {
 			method: 'POST',


### PR DESCRIPTION
## Summary

Add PKCE (`code_challenge`, `code_challenge_method`) and `nonce` support to the `/consent/info` endpoint request, matching the backend `consentInfoRequest` struct.

## Changes

- **`app/sso-authorize/store.ts`** — Added optional `codeChallenge`, `codeChallengeMethod`, `nonce` fields to `SsoAuthorizeParams`
- **`app/sso-authorize/useSsoAuthorize.ts`** — Parse `code_challenge`, `code_challenge_method`, `nonce` from URL query string
- **`services/sso/api.ts`** — Extended `consentInfo` payload type with optional PKCE + nonce fields
- **`app/sso-authorize/useConsent.ts`** — Conditionally pass PKCE/nonce params to the API call

## Notes

- All new fields are optional — existing flows without PKCE are unaffected
- Fields map to the backend Go struct:
  ```go
  type consentInfoRequest struct {
      CodeChallenge       string   `json:"code_challenge"`
      CodeChallengeMethod string   `json:"code_challenge_method"`
      OIDCNonce           string   `json:"nonce"`
  }
  ```