### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add Dependabot configuration for the pnpm-based web app so dependency updates are tracked automatically on a daily schedule.