### PR TITLE
chore: group dependabot updates by dependency type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      development-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"


### PR DESCRIPTION
Update Dependabot configuration to batch npm dependency updates into production and development groups, reducing PR noise while keeping changes scoped.